### PR TITLE
Add deletable label

### DIFF
--- a/cdpcli/clidriver.py
+++ b/cdpcli/clidriver.py
@@ -489,6 +489,9 @@ class CLIDriver(object):
             for doc in docs:
                 if doc is not None:
                     LOG.verbose(doc)
+                    # Ajout du label deletable sur tous les objets si la release est temporaire
+                    doc['metadata']['labels']['deletable'] = "true" if self._context.opt['--delete-labels'] else "false"
+
                     final_docs.append(doc)
                     if self.__get_team() != "empty_team":
                         doc= CLIDriver.addTeamLabel(doc,self.__get_team())
@@ -581,6 +584,14 @@ class CLIDriver(object):
     def addTeamLabel(doc,team):
         if doc['kind'] == 'Deployment' or doc['kind'] == 'StatefulSet' or doc['kind'] == 'Service':
              doc['metadata']['labels']['team'] = team
+             if 'template' in doc['spec'].keys():
+                doc['spec']['template']['metadata']['labels']['team'] = team
+        return doc
+
+    @staticmethod
+    def addDeletableLabel(doc,delay):
+        if doc['kind'] == 'Deployment' or doc['kind'] == 'StatefulSet' or doc['kind'] == 'Service':
+             doc['metadata']['labels']['deletable'] = "true"
              if 'template' in doc['spec'].keys():
                 doc['spec']['template']['metadata']['labels']['team'] = team
         return doc

--- a/cdpcli/clidriver.py
+++ b/cdpcli/clidriver.py
@@ -588,14 +588,6 @@ class CLIDriver(object):
                 doc['spec']['template']['metadata']['labels']['team'] = team
         return doc
 
-    @staticmethod
-    def addDeletableLabel(doc,delay):
-        if doc['kind'] == 'Deployment' or doc['kind'] == 'StatefulSet' or doc['kind'] == 'Service':
-             doc['metadata']['labels']['deletable'] = "true"
-             if 'template' in doc['spec'].keys():
-                doc['spec']['template']['metadata']['labels']['team'] = team
-        return doc
-
     def __buildTagAndPushOnDockerRegistry(self, tag):
         os.environ['CDP_TAG'] = tag
         if self._context.opt['--use-docker-compose']:

--- a/cdpcli/clidriver.py
+++ b/cdpcli/clidriver.py
@@ -490,7 +490,8 @@ class CLIDriver(object):
                 if doc is not None:
                     LOG.verbose(doc)
                     # Ajout du label deletable sur tous les objets si la release est temporaire
-                    doc['metadata']['labels']['deletable'] = "true" if self._context.opt['--delete-labels'] else "false"
+                    if "metadata" in doc and "labels" in doc['metadata']:
+                       doc['metadata']['labels']['deletable'] = "true" if self._context.opt['--delete-labels'] else "false"
 
                     final_docs.append(doc)
                     if self.__get_team() != "empty_team":


### PR DESCRIPTION
Pour l'auto-discovery Zabbix, les déploiements "temporaires" sont remontés. Pour les exclure, on peut se baser sur le label deletable. Cependant, ce label est positionné sur le namespace, ce qui est potentiellement faux vu que cela ne concerne que la release.
Ajout du label sur tous les objets de la release permettant d'être filtrés dans Prometheus
Le label sur le namespace a été laissé pour retro-compatibilité